### PR TITLE
Remove editable flag inside conanfile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,11 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 26)
 
-project(rsl_config CXX)
-add_library(rsl_config)
+project(rsl-config CXX)
+add_library(rsl-config)
 
-set_target_properties(rsl_config PROPERTIES OUTPUT_NAME rsl_config)
-target_compile_options(rsl_config PUBLIC 
+set_target_properties(rsl-config PROPERTIES OUTPUT_NAME rsl-config)
+target_compile_options(rsl-config PUBLIC
   "-stdlib=libc++"
   "-freflection"
   "-fannotation-attributes"
@@ -19,18 +19,18 @@ target_compile_options(rsl_config PUBLIC
   # "-ftime-trace"
   # "-fconstexpr-steps=10000000" # required to scan the global namespace
 )
-target_link_options(rsl_config PUBLIC "-stdlib=libc++" "-lc++abi")
-target_include_directories(rsl_config PUBLIC 
+target_link_options(rsl-config PUBLIC "-stdlib=libc++" "-lc++abi")
+target_include_directories(rsl-config PUBLIC
     $<INSTALL_INTERFACE:include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>)
 
 find_package(rsl-util REQUIRED)
-target_link_libraries(rsl_config PUBLIC rsl::util)
+target_link_libraries(rsl-config PUBLIC rsl::util)
 
 add_subdirectory(src)
 
 install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/ DESTINATION include)
-install(TARGETS rsl_config)
+install(TARGETS rsl-config)
 
 option(BUILD_EXAMPLES "Enable examples" ON)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -64,5 +64,5 @@ class rslconfigRecipe(ConanFile):
         self.cpp_info.components["config"].set_property("cmake_target_name", "rsl::config")
         self.cpp_info.components["config"].includedirs = ["include"]
         self.cpp_info.components["config"].libdirs = ["lib"]
-        self.cpp_info.components["config"].libs = ["rsl_config"]
+        self.cpp_info.components["config"].libs = ["rsl-config"]
         self.cpp_info.components["config"].requires = ["rsl-util::util"]

--- a/conanfile.py
+++ b/conanfile.py
@@ -20,9 +20,8 @@ class rslconfigRecipe(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "examples": [True, False],
-        "editable": [True, False]
     }
-    default_options = {"shared": False, "fPIC": True, "examples": False, "editable": False}
+    default_options = {"shared": False, "fPIC": True, "examples": False}
 
     # Sources are located in the same place as this recipe, copy them to the recipe
     exports_sources = "CMakeLists.txt", "src/*", "include/*"
@@ -54,9 +53,7 @@ class rslconfigRecipe(ConanFile):
                 "BUILD_EXAMPLES": self.options.examples,
             })
         cmake.build()
-        if self.options.editable:
-            # package is in editable mode - make sure it's installed after building
-            cmake.install()
+        cmake.install()
 
     def package(self):
         cmake = CMake(self)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -2,7 +2,7 @@ project(rsl)
 
 function(DEFINE_EXAMPLE TARGET)
   add_executable(example_${TARGET} "${TARGET}.cpp")
-  target_link_libraries(example_${TARGET} PRIVATE rsl_config)
+  target_link_libraries(example_${TARGET} PRIVATE rsl-config)
 endfunction()
 
 DEFINE_EXAMPLE(simple)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-target_sources(rsl_config PRIVATE 
+target_sources(rsl-config PRIVATE
   cli.cpp
   program_info.cpp
 )

--- a/src/json5/CMakeLists.txt
+++ b/src/json5/CMakeLists.txt
@@ -1,4 +1,4 @@
-target_sources(rsl_config PRIVATE 
+target_sources(rsl-config PRIVATE
   parser.cpp
   serializer.cpp
 )

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -5,12 +5,12 @@ project(PackageTest CXX)
 
 find_package(rsl-config REQUIRED)
 
-add_executable(rsl_config_test)
-target_compile_options(rsl_config_test PRIVATE "-freflection-latest")
-target_link_libraries(rsl_config_test PRIVATE rsl::config)
+add_executable(rsl-config-test)
+target_compile_options(rsl-config-test PRIVATE "-freflection-latest")
+target_link_libraries(rsl-config-test PRIVATE rsl::config)
 
 add_subdirectory(src)
-target_compile_definitions(rsl_config_test PRIVATE RSL_TEST_NAMESPACE=rsl)
+target_compile_definitions(rsl-config-test PRIVATE RSL_TEST_NAMESPACE=rsl)
   
 find_package(rsl-test REQUIRED)
-target_link_libraries(rsl_config_test PRIVATE rsl::test rsl::test_main)
+target_link_libraries(rsl-config-test PRIVATE rsl::test rsl::test_main)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -23,5 +23,5 @@ class pkgTestConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            cmd = os.path.join(self.cpp.build.bindir, "rsl_config_test")
+            cmd = os.path.join(self.cpp.build.bindir, "rsl-config-test")
             self.run(cmd, env="conanrun")

--- a/test_package/src/CMakeLists.txt
+++ b/test_package/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-target_sources(rsl_config_test PRIVATE 
+target_sources(rsl-config-test PRIVATE
   dummy.cpp
   trie.cpp
 )

--- a/test_package/src/json5/CMakeLists.txt
+++ b/test_package/src/json5/CMakeLists.txt
@@ -1,4 +1,4 @@
-target_sources(rsl_config_test 
+target_sources(rsl-config-test
   PRIVATE 
   fundamental.cpp
 )


### PR DESCRIPTION
Removed editable flag inside conanfile to always install library so that other libraries can use it as dependency 